### PR TITLE
fix: replace job dependency with tag-triggered publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-binaries:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact_name: context7-cli
+            asset_name: context7-cli-linux-x86_64
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            artifact_name: context7-cli
+            asset_name: context7-cli-macos-x86_64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact_name: context7-cli
+            asset_name: context7-cli-macos-aarch64
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    # Using dtolnay/rust-toolchain action maintained by David Tolnay,
+    # a trusted and prolific member of the Rust community (maintainer of serde, syn, and many other core crates)
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: ${{ matrix.target }}
+
+    - name: Build binary
+      run: cargo build --release --target ${{ matrix.target }}
+
+    - name: Prepare uncompressed binary
+      run: |
+        cp target/${{ matrix.target }}/release/${{ matrix.artifact_name }} ${{ matrix.asset_name }}
+
+    - name: Compress binary
+      run: |
+        tar czf ${{ matrix.asset_name }}.tar.gz ${{ matrix.asset_name }}
+
+    - name: Upload binaries to release
+      # Using softprops/action-gh-release action maintained by softprops.
+      # Most popular release package.
+      uses: softprops/action-gh-release@v2.4.1
+      with:
+        files: |
+          ${{ matrix.asset_name }}
+          ${{ matrix.asset_name }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,6 @@ jobs:
     name: Semantic Release
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
-    outputs:
-      new-release-published: ${{ steps.semantic.outputs.new-release-published }}
-      new-release-version: ${{ steps.semantic.outputs.new-release-version }}
 
     steps:
     - name: Checkout code
@@ -37,62 +34,6 @@ jobs:
       run: npm install @semantic-release/exec @semantic-release/changelog @semantic-release/git semantic-release
 
     - name: Release
-      id: semantic
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: npx semantic-release
-
-  build-binaries:
-    name: Build ${{ matrix.target }}
-    runs-on: ${{ matrix.os }}
-    needs: release
-    if: needs.release.outputs.new-release-published == 'true'
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            artifact_name: context7-cli
-            asset_name: context7-cli-linux-x86_64
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            artifact_name: context7-cli
-            asset_name: context7-cli-macos-x86_64
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            artifact_name: context7-cli
-            asset_name: context7-cli-macos-aarch64
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        ref: v${{ needs.release.outputs.new-release-version }}
-
-    # Using dtolnay/rust-toolchain action maintained by David Tolnay,
-    # a trusted and prolific member of the Rust community (maintainer of serde, syn, and many other core crates)
-    - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        targets: ${{ matrix.target }}
-
-    - name: Build binary
-      run: cargo build --release --target ${{ matrix.target }}
-
-    - name: Prepare uncompressed binary
-      run: |
-        cp target/${{ matrix.target }}/release/${{ matrix.artifact_name }} ${{ matrix.asset_name }}
-
-    - name: Compress binary
-      run: |
-        tar czf ${{ matrix.asset_name }}.tar.gz ${{ matrix.asset_name }}
-
-    - name: Upload binaries to release
-      # Using softprops/action-gh-release action maintained by softprops.
-      # Most popular release backage.
-      uses: softprops/action-gh-release@v2.4.1
-      with:
-        tag_name: v${{ needs.release.outputs.new-release-version }}
-        files: |
-          ${{ matrix.asset_name }}
-          ${{ matrix.asset_name }}.tar.gz


### PR DESCRIPTION
Changes:
- Create new publish.yml workflow triggered by v*.*.* tag pushes
- Remove build-binaries job from release.yml that was being skipped
- Simplify release.yml to only run semantic-release

The previous setup failed because semantic-release does not set GitHub Actions step outputs, causing the build-binaries job to be skipped. Now binaries are built automatically when semantic-release pushes tags, making the workflow simpler and more reliable.

Fixes #4