### PR TITLE
fix(publish): change workflow trigger from tag push to release event

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
- Replace tag push trigger with release published event
- Update workflow to trigger on release publication instead of version tags