### PR TITLE
fix(publish): add created event trigger to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   release:
-    types: [published]
+    types: [created, published]
 
 permissions:
   contents: write


### PR DESCRIPTION
- Add 'created' event type to release triggers
- Workflow now triggers on both 'created' and 'published' release events
- Ensures publish workflow runs when releases are created, not just published